### PR TITLE
feat✨/Side Menu post order by oldest to newest

### DIFF
--- a/src/components/SideMenu.astro
+++ b/src/components/SideMenu.astro
@@ -140,7 +140,12 @@ const categoryColors: Record<
   <div class="categories-list">
     {
       sortedCategories.map((category) => {
-        const posts = postsByCategory.get(category) || [];
+        let posts = postsByCategory.get(category) || [];
+        posts = posts.sort((a, b) => {
+          const dateA = a.data.publishDate || new Date(0);
+          const dateB = b.data.publishDate || new Date(0);
+          return dateA.getTime() - dateB.getTime();
+        });
         if (posts.length === 0) return null;
         const color = categoryColors[category];
 


### PR DESCRIPTION
En el Side Menu es mejor que se ordenen de viejos a nuevos, así podran encontrar primero los posts por ejemplo de Como empezar en Vue.js y después ya posts más avanzados, de otra manera no sabrán las bases de lo que hay publicado